### PR TITLE
recalculate content size if array changes (eg, when filtered)

### DIFF
--- a/addon/components/ember-list.js
+++ b/addon/components/ember-list.js
@@ -53,6 +53,7 @@ export default Ember.Component.extend({
   },
 
   didReceiveAttrs() {
+    var calculateSize = false;
     // Reset cells when cell layout or items array changes
     var cellLayout = this.attrs['cell-layout'];
     var items = this.attrs['items'];
@@ -62,13 +63,18 @@ export default Ember.Component.extend({
     if (this.cellLayout !== cellLayout || this.items !== items) {
       this.items = items;
       this.cellLayout = cellLayout;
+      calculateSize = true;
     }
 
     if (contentWidth !== this.width || contentHeight !== this.height) {
       this.width = contentWidth;
       this.height = contentHeight;
       this.calculateBounds();
-      this.calculateContentSize();
+      calculateSize = true;
+    }
+
+    if (calculateSize) {
+      Ember.run.scheduleOnce('afterRender', this, 'calculateContentSize');
     }
   },
 


### PR DESCRIPTION
Previously, if the length of the items array changed, the size of the content div did not. Now it will be recalculated and there won't be unnecessary space when the array is filtered.

An alternative approach would be to declare the items array/attribute formally in the component and then add an observer to it. That felt like more overhead vs. evaluating a local boolean given the existing structure. I can update in that direction if it's preferred, though.
